### PR TITLE
try with reg.finalizer; use .onLoad;

### DIFF
--- a/R/gdal_private.R
+++ b/R/gdal_private.R
@@ -8,7 +8,7 @@ NULL
 newRGDAL2Dataset = function(handle)
 {
     if ( is.null(handle) ) return(handle)
-    # reg.finalizer(handle, RGDAL_Close, TRUE)
+    reg.finalizer(handle, RGDAL_Close, FALSE)
     new("RGDAL2Dataset", handle = handle)
 }
 

--- a/R/ogr_private.R
+++ b/R/ogr_private.R
@@ -8,7 +8,7 @@ NULL
 newRGDAL2Datasource = function(handle)
 {
     if ( is.null(handle) ) return(NULL)
-    # reg.finalizer(handle, RGDAL_ReleaseDataSource, TRUE)
+    reg.finalizer(handle, RGDAL_ReleaseDataSource, FALSE)
     new("RGDAL2Datasource", handle = handle)
 }
 
@@ -22,21 +22,21 @@ newRGDAL2SQLLayer = function(handle, datasource, sql)
     if ( is.null(handle) ) return(NULL)
     f = function(lyrExtPtr)
       RGDAL_DS_ReleaseResultSet(datasource@handle, lyrExtPtr)
-    # reg.finalizer(handle, f, TRUE)
+    reg.finalizer(handle, f, FALSE)
     new("RGDAL2SQLLayer", handle = handle, datasource = datasource, sql = sql)
 }
 
 newRGDAL2Feature = function(handle)
 {
   if ( is.null(handle) ) return(NULL)
-  # reg.finalizer(handle, RGDAL_F_Destroy, TRUE)
+  reg.finalizer(handle, RGDAL_F_Destroy, FALSE)
   new("RGDAL2Feature", handle = handle)
 }
 
 newRGDAL2Geometry = function(handle)
 {
   if ( is.null(handle) ) return(NULL)
-  # reg.finalizer(handle, RGDAL_G_DestroyGeometry, TRUE)
+  reg.finalizer(handle, RGDAL_G_DestroyGeometry, FALSE)
   new("RGDAL2Geometry", handle = handle)
 }
 

--- a/R/ogr_public.R
+++ b/R/ogr_public.R
@@ -27,7 +27,7 @@ NULL
 openOGR = function(fname, readonly = TRUE)
 {
     x = RGDAL_OGROpen(fname, readonly)
-    if ( is.null(x) ) stop("Unable to open file")
+    if ( is.null(x) ) stop(paste("Unable to open file", fname))
     newRGDAL2Datasource(x)
 }
 

--- a/R/pkg.R
+++ b/R/pkg.R
@@ -57,14 +57,13 @@ printPkgBanner = function()
   }
 }
 
-.onAttach = function(libname, pkgname)
+.onLoad = function(libname, pkgname)
 {
     printPkgBanner()
     GDALInit()
 }
 
-.onDetach = function(libpath)
+.onUnload = function(libname, pkgname)
 {
   RGDAL_CleanupAll()
 }
-

--- a/R/srs.R
+++ b/R/srs.R
@@ -11,7 +11,7 @@ NULL
 
 newRGDAL2SpatialRef = function(handle)
 {
-    # reg.finalizer(handle, RGDAL_OSRRelease, TRUE)
+    reg.finalizer(handle, RGDAL_OSRRelease, FALSE)
     new("RGDAL2SpatialRef", handle = handle)
 }
 

--- a/configure.in
+++ b/configure.in
@@ -32,10 +32,10 @@ else
 	exit 1
 fi
 
-if test ! -e src/RcppExports.cpp
-then
+#if test ! -e src/RcppExports.cpp
+#then
   ${R_HOME}/bin/Rscript -e "Rcpp:::compileAttributes()"
-fi
+#fi
 
 if test ! -e src/RcppExports.cpp
 then

--- a/src/gdal_rcpp.cpp
+++ b/src/gdal_rcpp.cpp
@@ -983,6 +983,7 @@ void RGDALWriteRasterBand(BandH hRB, SEXP data,
                           int nDSXOff, int nDSYOff,
                           int nDSXSize, int nDSYSize)
 {
+	CPLErr err;
     if ( GDALGetRasterAccess(*hRB) == GA_ReadOnly )
         stop("Raster band is read-only\n");
     void* buf;
@@ -995,7 +996,7 @@ void RGDALWriteRasterBand(BandH hRB, SEXP data,
         for ( size_t r = 0; r != nr; ++r )
             for ( size_t c = 0; c != nc; ++c )
                 ((int*)buf)[r * nc + c] = scale * INTEGER(data)[c * nr + r] - offset;
-        GDALRasterIO(*hRB, GF_Write,
+        err = GDALRasterIO(*hRB, GF_Write,
                      nDSXOff, nDSYOff,
                      nDSXSize, nDSYSize,
                      buf, nc, nr, GDT_Int32,
@@ -1008,13 +1009,14 @@ void RGDALWriteRasterBand(BandH hRB, SEXP data,
         for ( size_t r = 0; r != nr; ++r )
             for ( size_t c = 0; c != nc; ++c )
                 ((double*)buf)[r * nc + c] = scale * REAL(data)[c * nr + r] - offset;
-        GDALRasterIO(*hRB, GF_Write,
+        err = GDALRasterIO(*hRB, GF_Write,
                      nDSXOff, nDSYOff,
                      nDSXSize, nDSYSize,
                      buf, nc, nr, GDT_Float64,
                      0, 0);
         return;
     }
+	// EJP TODO: do something with err, if needed?
     stop("Unsupported data type\n");
 }
 


### PR DESCRIPTION
using `.onLoad` lets other packages import rgdal2.
`reg.finalizer` with `onexit=FALSE` frees objects in the correct order.
adding `CPLErr err` resolves the remaining compiler warning.
